### PR TITLE
Add Supabase service client and ingest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Supabase
+
+Server routes that write to the database, such as `/api/ingest`, require the Supabase service key. Set `SUPABASE_SERVICE_KEY` in your environment when deploying or running the server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "wow-ai-tool",
 			"version": "0.0.1",
+			"dependencies": {
+				"@supabase/supabase-js": "^2.51.0"
+			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
 				"@eslint/js": "^9.18.0",
@@ -1175,6 +1178,81 @@
 				"win32"
 			]
 		},
+		"node_modules/@supabase/auth-js": {
+			"version": "2.71.0",
+			"resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.0.tgz",
+			"integrity": "sha512-OMYNbhGa1Cj4stalJq0VoHm5l7Sj/xY0j9CiYEQCikbQmtiDG3c27EIFA4OD+NxuoHTZmjaW8VJlS3SP+yasEA==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/functions-js": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+			"integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/node-fetch": {
+			"version": "2.6.15",
+			"resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+			"integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			}
+		},
+		"node_modules/@supabase/postgrest-js": {
+			"version": "1.19.4",
+			"resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+			"integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/realtime-js": {
+			"version": "2.11.15",
+			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+			"integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.13",
+				"@types/phoenix": "^1.6.6",
+				"@types/ws": "^8.18.1",
+				"isows": "^1.0.7",
+				"ws": "^8.18.2"
+			}
+		},
+		"node_modules/@supabase/storage-js": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+			"integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/supabase-js": {
+			"version": "2.51.0",
+			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.51.0.tgz",
+			"integrity": "sha512-jG70XoNFcX3z0h/No0t1Aoc3zoHPtMQk5zaM5v3+sCJ/v5Z3qyoHYkGIg1JUycINPsuuAASZ4ZS43YO6H5wMoA==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/auth-js": "2.71.0",
+				"@supabase/functions-js": "2.4.5",
+				"@supabase/node-fetch": "2.6.15",
+				"@supabase/postgrest-js": "1.19.4",
+				"@supabase/realtime-js": "2.11.15",
+				"@supabase/storage-js": "2.7.1"
+			}
+		},
 		"node_modules/@sveltejs/acorn-typescript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
@@ -1578,6 +1656,30 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.0.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+			"integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.8.0"
+			}
+		},
+		"node_modules/@types/phoenix": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+			"integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.37.0",
@@ -2936,6 +3038,21 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/isows": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+			"integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"ws": "*"
+			}
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -4425,7 +4542,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ts-api-utils": {
@@ -4491,6 +4607,12 @@
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+			"license": "MIT"
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -4608,14 +4730,12 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",
@@ -4741,6 +4861,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^7.0.4"
+	},
+	"dependencies": {
+		"@supabase/supabase-js": "^2.51.0"
 	}
 }

--- a/src/lib/cfg.ts
+++ b/src/lib/cfg.ts
@@ -1,0 +1,7 @@
+import { env } from '$env/dynamic/private';
+
+export const cfg = {
+	SUPABASE_URL: env.SUPABASE_URL as string,
+	SUPABASE_ANON_KEY: env.SUPABASE_ANON_KEY as string,
+	SUPABASE_SERVICE_KEY: env.SUPABASE_SERVICE_KEY as string
+};

--- a/src/lib/supa_service.ts
+++ b/src/lib/supa_service.ts
@@ -1,0 +1,4 @@
+import { createClient } from '@supabase/supabase-js';
+import { cfg } from './cfg';
+
+export const supabaseService = createClient(cfg.SUPABASE_URL, cfg.SUPABASE_SERVICE_KEY);

--- a/src/routes/api/ingest/+server.ts
+++ b/src/routes/api/ingest/+server.ts
@@ -1,0 +1,15 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { supabaseService } from '$lib/supa_service';
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const data = await request.json();
+		const { error } = await supabaseService.from('ingest').insert(data);
+		if (error) {
+			return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+		}
+		return new Response(JSON.stringify({ success: true }), { status: 200 });
+	} catch {
+		return new Response(JSON.stringify({ error: 'Invalid request' }), { status: 400 });
+	}
+};


### PR DESCRIPTION
## Summary
- add Supabase library
- provide `cfg` helper for env vars and `supa_service` for service-level client
- create `/api/ingest` route using service client
- document the need for `SUPABASE_SERVICE_KEY` in README

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6878d08014ac8325b77c974fbba72573